### PR TITLE
Sorting bug that caused duplicate and/or missing file & folders

### DIFF
--- a/list.html
+++ b/list.html
@@ -381,16 +381,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                 // sort array of S3 objects based on name key in objects
                 function sortObjectsArray(objectsArray) {
-                    return objectsArray.sort(function(a,b) {
-                        return objectsArray.sort(function(a, b) {
-                            if (a.name > b.name) {
-                                return 1;
-                            }
-                            if (a.name < b.name) {
-                                return -1;
-                            }
-                            return 0;  // a === b
-                        });
+                    return objectsArray.sort(function(a, b) {
+                        if (a.name > b.name) {
+                            return 1;
+                        }
+                        if (a.name < b.name) {
+                            return -1;
+                        }
+                        return 0;  // a === b
                     });
                 }
 


### PR DESCRIPTION
This bug looks like a typo, and strangely it almost works but sometimes causes duplicates of the first file/folder, and hid the second file/folder.